### PR TITLE
Added sample code in test cases for array properties.

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -101,7 +101,7 @@ pluginTester({
         // sitrep
         fn() {
           const [a, b, c, d] = x.split("_");
-          return a + b + c + alias;
+          return a + b + c + d;
         }
       `
     },

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -96,6 +96,16 @@ pluginTester({
       `
     },
     {
+      title: 'array properties',
+      code: `
+        // sitrep
+        fn() {
+          const [a, b, c, d] = x.split("_");
+          return a + b + c + alias;
+        }
+      `
+    },
+    {
       title: 'class methods',
       code: `
         class Boom {


### PR DESCRIPTION
Added a sample code for array properties in the test cases which is failing currently.

`const [a, b, c, d] = x.split("_");`

The above code throws this error

> Module build failed: TypeError: Cannot read property 'slice' of undefined
    at VariableDeclaration.decls.forEach.dec (node_modules/babel-plugin-sitrep/src/index.js:84:15)